### PR TITLE
fix(ci): correct sc-ui clone URL and add token auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ name: ci
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, feat/nuxt4]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, feat/nuxt4]
 
 env:
   NODE_VERSION: "22"
   PNPM_VERSION: "10"
-  UI_REPO_URL: "https://github.com/stuartclark/ui.git"
+  UI_REPO_URL: "https://x-access-token:${{ secrets.UI_REPO_TOKEN }}@github.com/Decipher/sc-ui.git"
 
 jobs:
   build:
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: site
-          path: nuxt/.output/public
+          path: nuxt/dist
           retention-days: 1
 
   seo:
@@ -107,7 +107,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: site
-          path: nuxt/.output/public
+          path: nuxt/dist
 
       - name: Install Playwright Chromium
         run: pnpm --dir nuxt exec playwright install --with-deps chromium

--- a/nuxt/app/layouts/default.vue
+++ b/nuxt/app/layouts/default.vue
@@ -30,8 +30,8 @@ const isDev = inject('devMode', import.meta.dev)
     <SCAppHeader :links="navLinks" contact-label="Contact" @contact="contactOpen = true">
       <template #menu-footer>
         <SCStatusPill available />
-        <div class="mt-3 flex gap-4 font-mono text-xs text-neutral-400">
-          <NuxtLink v-for="l in elsewhereLinks" :key="l.to" :to="l.to" class="hover:text-neutral-200">
+        <div class="mt-3 flex gap-4 font-mono text-xs text-muted">
+          <NuxtLink v-for="l in elsewhereLinks" :key="l.to" :to="l.to" class="hover:text-highlighted no-underline">
             {{ l.label }}
           </NuxtLink>
         </div>


### PR DESCRIPTION
Fixes GitHub Actions failing to clone the private `Decipher/sc-ui` repo.

- URL was `github.com/stuartclark/ui` → corrected to `github.com/Decipher/sc-ui`
- Added `x-access-token` auth so the private repo can be cloned (`UI_REPO_TOKEN` secret)
- Artifact paths already corrected in prior commit (`.output/public` → `dist`)