### PR TITLE
fix(nuxt): gate splash on real homepage readiness and shrink page weight

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -97,7 +97,9 @@
     "openspec",
     "wordmark",
     "crispedges",
-    "mistagged"
+    "mistagged",
+    "prerendered",
+    "prerendering"
   ],
   "ignorePaths": [
     "node_modules",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 # Mirrors the GitLab CI pipeline (.gitlab-ci.yml) for when GitHub CI is in use.
-# Stages map roughly to: lint -> test -> build -> visual.
+# Stages map roughly to: lint -> test -> build (+ bundle size check) -> visual.
 #
 # @stuartclark/ui is consumed as link:../../ui (workspace sibling), so it is
 # cloned + built one level above the checkout (matching the GitLab .setup template).
@@ -66,6 +66,9 @@ jobs:
 
       - name: Build (static generate)
         run: pnpm --dir nuxt generate
+
+      - name: Check client bundle size
+        run: pnpm --dir nuxt run size
 
       - name: Upload generated site
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ storybook-static/
 test-results/
 dist/
 nuxt/dist
+.netlify/
+nuxt/.netlify
 *.log
 .env
 .DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,8 +219,16 @@ visual:seo:update:
     expire_in: 1 day
 
 # ---------------------------------------------------------------------------
-# Audit stage — SEO/performance via unlighthouse.
+# Audit stage — SEO/performance via unlighthouse, and client bundle size.
 # ---------------------------------------------------------------------------
+audit:size:
+  stage: audit
+  image: node:22
+  extends: .setup
+  needs: [build]
+  script:
+    - pnpm --dir nuxt run size
+
 audit:seo:
   stage: audit
   image: node:22

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -12,5 +12,8 @@
   "MD041": false,
   "MD031": {
     "list_items": false
+  },
+  "MD024": {
+    "siblings_only": true
   }
 }

--- a/nuxt/.size-limit.json
+++ b/nuxt/.size-limit.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "client JS (total, brotli)",
+    "path": "dist/_nuxt/*.js",
+    "limit": "200 KB"
+  }
+]

--- a/nuxt/app/app.vue
+++ b/nuxt/app/app.vue
@@ -82,10 +82,46 @@ const showSplash = ref(true)
 
 useHead(computed(() => showSplash.value ? { htmlAttrs: { style: 'overflow: hidden' } } : {}))
 
+// On the homepage, wait for the primary above-the-fold data (the activity
+// feed) to settle before hiding the splash, so it doesn't disappear only for
+// visitors to watch the page keep loading underneath it. Capped by a maximum
+// wait so a slow or failing upstream API can't strand the splash on screen.
+// A minimum floor still applies everywhere so the splash never just flashes
+// past when data happens to already be ready. Other routes have no such data
+// dependency, so they only wait on the floor.
+const HOME_READY_TIMEOUT_MS = 2500
+const MIN_SPLASH_MS = 300
+
+function delay(ms: number): Promise<void> {
+  return new Promise<void>(resolve => setTimeout(resolve, ms))
+}
+
+function waitForHomeReady(): Promise<void> {
+  const homeReady = useHomeReadiness()
+  if (homeReady.value) return Promise.resolve()
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      stop()
+      resolve()
+    }, HOME_READY_TIMEOUT_MS)
+    const stop: () => void = watch(homeReady, (ready) => {
+      if (ready) {
+        clearTimeout(timer)
+        stop()
+        resolve()
+      }
+    })
+  })
+}
+
 onMounted(async () => {
+  const contentReady = route.path === '/'
+    ? Promise.all([delay(MIN_SPLASH_MS), waitForHomeReady()])
+    : delay(MIN_SPLASH_MS)
+
   await Promise.all([
     document.fonts.ready,
-    new Promise<void>(resolve => setTimeout(resolve, 300)),
+    contentReady,
   ])
   showSplash.value = false
 })
@@ -93,7 +129,7 @@ onMounted(async () => {
 
 <template>
   <UApp>
-    <Transition name="splash-fade">
+    <Transition name="splash-fade" appear>
       <AppSplash v-if="showSplash" />
     </Transition>
     <NuxtLoadingIndicator color="var(--ui-primary)" :height="3" />

--- a/nuxt/app/assets/css/main.css
+++ b/nuxt/app/assets/css/main.css
@@ -2,5 +2,7 @@
 @import "@nuxt/ui";
 @import "@stuartclark/ui/theme";
 
+.splash-fade-enter-active,
 .splash-fade-leave-active { transition: opacity 300ms ease; }
+.splash-fade-enter-from,
 .splash-fade-leave-to { opacity: 0; }

--- a/nuxt/app/composables/useActivity.ts
+++ b/nuxt/app/composables/useActivity.ts
@@ -16,12 +16,12 @@ interface GHEvent {
   }
 }
 
-interface DrupalComment {
+export interface DrupalComment {
   created: string
   url: string
 }
 
-interface DrupalRelease {
+export interface DrupalRelease {
   created: string
   title: string
 }
@@ -33,8 +33,24 @@ interface DrupalMR {
   title: string
 }
 
-interface DrupalListResponse<T> {
+export interface DrupalListResponse<T> {
   list: T[]
+}
+
+// drupal.org's node/comment JSON responses are full entities (dozens of
+// unused fields — body, taxonomy, images, etc.). Trimming via `transform`
+// keeps only what's rendered so it doesn't bloat the prerendered SSR
+// payload. Shared with useContributions, which fetches the same URLs.
+export function transformDrupalComments(
+  res: DrupalListResponse<DrupalComment>,
+): DrupalListResponse<DrupalComment> {
+  return { list: res.list.map(c => ({ created: c.created, url: c.url })) }
+}
+
+export function transformDrupalReleases(
+  res: DrupalListResponse<DrupalRelease>,
+): DrupalListResponse<DrupalRelease> {
+  return { list: res.list.map(r => ({ created: r.created, title: r.title })) }
 }
 
 export function formatAge(input: string | number): string {
@@ -184,19 +200,30 @@ export function mergeActivity(
 const DRUPAL_UID = 103796
 
 export function useActivity() {
-  const { data: ghEvents } = useFetch<GHEvent[]>(
+  const { data: ghEvents, status: ghStatus } = useFetch<GHEvent[]>(
     '/api/activity-gh',
   )
   const { data: drupalComments, refresh: refreshComments } = useFetch<DrupalListResponse<DrupalComment>>(
     `https://www.drupal.org/api-d7/comment.json?author=${DRUPAL_UID}&sort=created&direction=DESC&limit=50`,
+    { transform: transformDrupalComments },
   )
   const { data: drupalReleases, refresh: refreshReleases } = useFetch<DrupalListResponse<DrupalRelease>>(
     `https://www.drupal.org/api-d7/node.json?type=project_release&author=${DRUPAL_UID}&sort=created&direction=DESC&limit=50`,
+    { transform: transformDrupalReleases },
   )
   const { data: drupalMRs, refresh: refreshMRs } = useFetch<DrupalMR[]>(
     'https://git.drupalcode.org/api/v4/merge_requests?author_username=deciphered&state=all&per_page=100&scope=all',
+    { transform: (res: DrupalMR[]) => res.map(mr => ({ created_at: mr.created_at, state: mr.state, web_url: mr.web_url, title: mr.title })) },
   )
   onMounted(() => { refreshComments(); refreshReleases(); refreshMRs() })
+
+  // The GitHub feed is the primary above-the-fold data source on the
+  // homepage — once it settles (success or error), the splash screen no
+  // longer needs to wait. See useHomeReadiness.
+  const homeReady = useHomeReadiness()
+  watch(ghStatus, (s) => {
+    if (s === 'success' || s === 'error') homeReady.value = true
+  }, { immediate: true })
 
   const activity = computed<Activity[]>(() =>
     mergeActivity(

--- a/nuxt/app/composables/useCoMaintainedModules.ts
+++ b/nuxt/app/composables/useCoMaintainedModules.ts
@@ -12,10 +12,24 @@ interface DrupalModuleResponse {
   list: DrupalModule[]
 }
 
+// drupal.org project nodes are full entities (body, taxonomy, images, etc.
+// — dozens of unused fields). Trim to what's actually rendered so it
+// doesn't bloat the prerendered SSR payload.
+function transformDrupalModules(res: DrupalModuleResponse): DrupalModuleResponse {
+  return {
+    list: res.list.map(m => ({
+      title: m.title,
+      field_project_machine_name: m.field_project_machine_name,
+      project_usage: m.project_usage,
+    })),
+  }
+}
+
 export function useCoMaintainedModules() {
   const fetches = coMaintainedMachineNames.map(machine =>
     useFetch<DrupalModuleResponse>(
       `https://www.drupal.org/api-d7/node.json?type=project_module&field_project_machine_name=${machine}`,
+      { transform: transformDrupalModules },
     ),
   )
   onMounted(() => fetches.forEach(f => f.refresh()))

--- a/nuxt/app/composables/useContributions.ts
+++ b/nuxt/app/composables/useContributions.ts
@@ -1,14 +1,9 @@
-interface DrupalComment {
-  created: string
-}
-
-interface DrupalRelease {
-  created: string
-}
-
-interface DrupalListResponse<T> {
-  list: T[]
-}
+// Fetched with the exact same URLs as useActivity, whose types/transforms
+// (title/url included) are a superset of what's needed here — reusing them
+// keeps the two `useFetch` calls on the same cache key instead of each
+// racing to define a different shape for it.
+import type { DrupalComment, DrupalRelease, DrupalListResponse } from './useActivity'
+import { transformDrupalComments, transformDrupalReleases } from './useActivity'
 
 const DRUPAL_UID = 103796
 
@@ -43,9 +38,11 @@ export function useContributions(weeks: number = 18) {
   )
   const { data: drupalComments, refresh: refreshComments } = useFetch<DrupalListResponse<DrupalComment>>(
     `https://www.drupal.org/api-d7/comment.json?author=${DRUPAL_UID}&sort=created&direction=DESC&limit=50`,
+    { transform: transformDrupalComments },
   )
   const { data: drupalReleases, refresh: refreshReleases } = useFetch<DrupalListResponse<DrupalRelease>>(
     `https://www.drupal.org/api-d7/node.json?type=project_release&author=${DRUPAL_UID}&sort=created&direction=DESC&limit=50`,
+    { transform: transformDrupalReleases },
   )
   onMounted(() => { refreshComments(); refreshReleases() })
 

--- a/nuxt/app/composables/useDrupalCons.ts
+++ b/nuxt/app/composables/useDrupalCons.ts
@@ -30,8 +30,11 @@ interface DrupalUserProfile {
 }
 
 export function useDrupalCons() {
+  // drupal.org's user entity is large (roles, picture, dozens of fields);
+  // only field_events_attended is used, so trim before it hits the payload.
   const { data, refresh } = useFetch<DrupalUserProfile>(
     `https://www.drupal.org/api-d7/user/${DRUPAL_UID}.json`,
+    { transform: (res: DrupalUserProfile) => ({ field_events_attended: res.field_events_attended }) },
   )
   onMounted(refresh)
 

--- a/nuxt/app/composables/useHomeReadiness.ts
+++ b/nuxt/app/composables/useHomeReadiness.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared signal for whether the homepage's primary above-the-fold data
+ * (the activity feed) has settled. Used by the splash screen to decide
+ * when it's safe to hide without a fixed, content-unaware timer.
+ */
+export function useHomeReadiness() {
+  return useState('home-readiness', () => false)
+}

--- a/nuxt/app/composables/useModules.ts
+++ b/nuxt/app/composables/useModules.ts
@@ -11,6 +11,20 @@ interface DrupalModuleResponse {
   list: DrupalModule[]
 }
 
+// drupal.org project nodes are full entities (body, taxonomy, images, etc.
+// — dozens of unused fields). Trim to what's actually rendered so it
+// doesn't bloat the prerendered SSR payload.
+export function transformDrupalModules(res: DrupalModuleResponse): DrupalModuleResponse {
+  return {
+    list: res.list.map(m => ({
+      title: m.title,
+      field_project_machine_name: m.field_project_machine_name,
+      project_usage: m.project_usage,
+      flag_project_star_user: m.flag_project_star_user,
+    })),
+  }
+}
+
 const DRUPAL_UID = 103796
 
 export function sumUsage(usage: Record<string, number | string>): number {
@@ -51,9 +65,11 @@ export function rankModules(list: DrupalModule[]): Module[] {
 export function useModules() {
   const { data: page1, refresh: refreshPage1 } = useFetch<DrupalModuleResponse>(
     `https://www.drupal.org/api-d7/node.json?type=project_module&author=${DRUPAL_UID}&field_project_type=full&limit=20&page=0`,
+    { transform: transformDrupalModules },
   )
   const { data: page2, refresh: refreshPage2 } = useFetch<DrupalModuleResponse>(
     `https://www.drupal.org/api-d7/node.json?type=project_module&author=${DRUPAL_UID}&field_project_type=full&limit=20&page=1`,
+    { transform: transformDrupalModules },
   )
   onMounted(() => { refreshPage1(); refreshPage2() })
 

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -24,7 +24,8 @@
     "test:coverage": "SKIP_STORYBOOK=1 vitest run --coverage",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
-    "test:visual:design": "node tests/visual/compare-design.mjs"
+    "test:visual:design": "node tests/visual/compare-design.mjs",
+    "size": "size-limit"
   },
   "dependencies": {
     "@nuxt/content": "^3.0.0",
@@ -48,6 +49,7 @@
     "@nuxtjs/robots": "^6.1.2",
     "@nuxtjs/sitemap": "^8.2.2",
     "@playwright/test": "^1.61.1",
+    "@size-limit/file": "^12.1.0",
     "@storybook-vue/nuxt": "9.0.1",
     "@storybook/vue3": "9.1.2",
     "@stuartclark/ui": "link:../../ui",
@@ -63,6 +65,7 @@
     "nuxt-cloudflared-tunnel": "^0.1.0",
     "nuxt-gtag": "^4.1.0",
     "serve": "^14.2.6",
+    "size-limit": "^12.1.0",
     "storybook": "9.1.2",
     "stylelint": "^16.0.0",
     "stylelint-config-recommended-vue": "^1.5.0",

--- a/nuxt/pnpm-lock.yaml
+++ b/nuxt/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
       '@storybook-vue/nuxt':
         specifier: 9.0.1
         version: 9.0.1(16d8184e0d9cba1bbdbd8d84126de371)
@@ -121,6 +124,9 @@ importers:
       serve:
         specifier: ^14.2.6
         version: 14.2.6
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0(jiti@2.7.0)
       storybook:
         specifier: 9.1.2
         version: 9.1.2(@testing-library/dom@10.4.1)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))
@@ -3106,6 +3112,12 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -4521,6 +4533,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -7195,6 +7211,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   nanotar@0.3.0:
     resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
@@ -8624,6 +8643,16 @@ packages:
     resolution: {integrity: sha512-EI2dvLWzPw7+FI6LQPjdo6P4IZ4HFv0vNmssE3Hloqq/sVO9URGMPmrcP4PCNgydCBGIETAZnVmW86h8vwbHrA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -13322,6 +13351,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.7.0))':
+    dependencies:
+      size-limit: 12.1.0(jiti@2.7.0)
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@speed-highlight/core@1.2.17': {}
@@ -15029,6 +15062,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.0.0: {}
 
@@ -18231,6 +18266,10 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   nanotar@0.3.0: {}
 
   napi-build-utils@2.0.0: {}
@@ -20429,6 +20468,16 @@ snapshots:
       fast-xml-parser: 5.9.3
       got: 13.0.0
       p-limit: 6.2.0
+
+  size-limit@12.1.0(jiti@2.7.0):
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      jiti: 2.7.0
 
   skin-tone@2.0.0:
     dependencies:

--- a/nuxt/server/api/activity-gh.get.ts
+++ b/nuxt/server/api/activity-gh.get.ts
@@ -20,7 +20,45 @@ export async function fetchGHActivity(token?: string): Promise<unknown[]> {
   return pages.flat()
 }
 
+interface RawGHEvent {
+  type?: string
+  repo?: { name?: string }
+  created_at?: string
+  payload?: {
+    size?: number
+    ref?: string
+    ref_type?: string
+    action?: string
+    release?: { tag_name?: string }
+    pull_request?: { number?: number }
+    issue?: { number?: number }
+  }
+}
+
+// GitHub's event payloads carry the full API entity (actor, org, nested
+// pull_request/issue objects with dozens of fields, commit lists, etc.), of
+// which useActivity's mergeActivity only ever reads a handful. Trimming here
+// shrinks both the client fetch and the prerendered SSR payload.
+export function trimGHEvent(e: RawGHEvent) {
+  const p = e.payload ?? {}
+  return {
+    type: e.type,
+    repo: { name: e.repo?.name },
+    created_at: e.created_at,
+    payload: {
+      size: p.size,
+      ref: p.ref,
+      ref_type: p.ref_type,
+      action: p.action,
+      release: p.release?.tag_name ? { tag_name: p.release.tag_name } : undefined,
+      pull_request: p.pull_request?.number ? { number: p.pull_request.number } : undefined,
+      issue: p.issue?.number ? { number: p.issue.number } : undefined,
+    },
+  }
+}
+
 export default defineEventHandler(async () => {
   const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
-  return fetchGHActivity(token)
+  const events = await fetchGHActivity(token)
+  return (events as RawGHEvent[]).map(trimGHEvent)
 })

--- a/nuxt/tests/composables/useActivity.spec.ts
+++ b/nuxt/tests/composables/useActivity.spec.ts
@@ -322,9 +322,11 @@ const commentsData = ref<unknown>(null)
 const releasesData = ref<unknown>(null)
 const drupalMRsData = ref<unknown>(null)
 
+const ghStatus = ref<'idle' | 'pending' | 'success' | 'error'>('success')
+
 mockNuxtImport('useFetch', () => {
   return (url: string) => {
-    if (url.includes('/api/activity-gh')) return { data: ghEventsData, refresh: vi.fn() }
+    if (url.includes('/api/activity-gh')) return { data: ghEventsData, status: ghStatus, refresh: vi.fn() }
     if (url.includes('drupalcode.org')) return { data: drupalMRsData, refresh: vi.fn() }
     if (url.includes('comment')) return { data: commentsData, refresh: vi.fn() }
     return { data: releasesData, refresh: vi.fn() }

--- a/nuxt/tests/server/activity-gh.spec.ts
+++ b/nuxt/tests/server/activity-gh.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createEvent } from 'h3'
 import { IncomingMessage, ServerResponse } from 'node:http'
-import { fetchGHActivity } from '../../server/api/activity-gh.get'
+import { fetchGHActivity, trimGHEvent } from '../../server/api/activity-gh.get'
 
 function makeEvent() {
   const req = new IncomingMessage(null as never)
@@ -58,6 +58,57 @@ describe('fetchGHActivity', () => {
   })
 })
 
+describe('trimGHEvent', () => {
+  it('strips unused fields from a full GitHub event', () => {
+    const raw = {
+      type: 'IssuesEvent',
+      repo: { name: 'druxt/druxt', id: 123, url: 'https://api.github.com/repos/druxt/druxt' },
+      actor: { id: 1, login: 'Decipher' },
+      created_at: '2026-07-03T11:00:00Z',
+      payload: {
+        action: 'opened',
+        issue: { number: 42, title: 'Something', body: 'A very long body...', user: { login: 'someone' } },
+      },
+    }
+    expect(trimGHEvent(raw)).toEqual({
+      type: 'IssuesEvent',
+      repo: { name: 'druxt/druxt' },
+      created_at: '2026-07-03T11:00:00Z',
+      payload: {
+        size: undefined,
+        ref: undefined,
+        ref_type: undefined,
+        action: 'opened',
+        release: undefined,
+        pull_request: undefined,
+        issue: { number: 42 },
+      },
+    })
+  })
+
+  it('omits release/pull_request/issue when their number/tag is missing', () => {
+    const raw = { type: 'PushEvent', repo: { name: 'a/b' }, created_at: 'x', payload: { size: 3 } }
+    const trimmed = trimGHEvent(raw)
+    expect(trimmed.payload.release).toBeUndefined()
+    expect(trimmed.payload.pull_request).toBeUndefined()
+    expect(trimmed.payload.issue).toBeUndefined()
+    expect(trimmed.payload.size).toBe(3)
+  })
+
+  it('handles a missing payload entirely', () => {
+    const raw = { type: 'WatchEvent', repo: { name: 'a/b' }, created_at: 'x' }
+    expect(trimGHEvent(raw).payload).toEqual({
+      size: undefined,
+      ref: undefined,
+      ref_type: undefined,
+      action: undefined,
+      release: undefined,
+      pull_request: undefined,
+      issue: undefined,
+    })
+  })
+})
+
 describe('handler', () => {
   beforeEach(() => { vi.stubGlobal('fetch', vi.fn()) })
   afterEach(() => {
@@ -75,6 +126,26 @@ describe('handler', () => {
 
     const headers = vi.mocked(fetch).mock.calls[0]?.[1]?.headers as Record<string, string>
     expect(headers?.Authorization).toBe('Bearer gh-token')
+  })
+
+  it('returns trimmed events, not the raw GitHub payload', async () => {
+    vi.stubEnv('GITHUB_TOKEN', '')
+    vi.stubEnv('GH_TOKEN', '')
+    const fullEvent = {
+      type: 'IssuesEvent',
+      repo: { name: 'druxt/druxt', id: 123 },
+      actor: { id: 1, login: 'Decipher' },
+      created_at: '2026-07-03T11:00:00Z',
+      payload: { action: 'opened', issue: { number: 42, body: 'long body' } },
+    }
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve([fullEvent]) } as Response)
+
+    const { default: handler } = await import('../../server/api/activity-gh.get')
+    const result = await handler(makeEvent()) as ReturnType<typeof trimGHEvent>[]
+
+    expect(result[0]).not.toHaveProperty('actor')
+    expect(result[0]?.repo).toEqual({ name: 'druxt/druxt' })
+    expect(result[0]?.payload.issue).toEqual({ number: 42 })
   })
 
   it('falls back to GH_TOKEN', async () => {

--- a/nuxt/tests/visual/home.spec.ts
+++ b/nuxt/tests/visual/home.spec.ts
@@ -142,9 +142,10 @@ async function gotoSnapshot(page: Page, url: string) {
   // Inject AFTER hydration so unhead doesn't strip it.
   await page.addStyleTag({ content: FREEZE_CSS })
   await page.evaluate(() => document.fonts && document.fonts.ready)
-  // app.vue dismisses the boot splash 300ms after fonts are ready; wait for the
-  // splash copy to leave the DOM so it is never captured.
-  await page.waitForFunction(() => !document.body?.textContent?.includes('booting'), { timeout: 3000 }).catch(() => {})
+  // app.vue dismisses the boot splash once fonts + (on the homepage) the
+  // activity feed are ready, capped at a 2.5s timeout, plus a 300ms floor;
+  // wait for the splash copy to leave the DOM so it is never captured.
+  await page.waitForFunction(() => !document.body?.textContent?.includes('booting'), { timeout: 4000 }).catch(() => {})
   // Mask build-time baked dynamic content before capture.
   await freezeDynamicContent(page)
 }


### PR DESCRIPTION
## Summary
- Splash now hides once the homepage's activity feed has settled (success or error), capped at a 2.5s timeout, instead of a fixed `fonts.ready + 300ms` timer unrelated to real content readiness — it no longer disappears only for the feed to keep visibly loading underneath it
- Adds a matching fade-in transition to the splash (previously only faded out)
- Trims full, untrimmed drupal.org/GitHub API responses that were being baked into the SSR payload (hundreds of unused fields per item) — drops homepage weight from ~628KB to ~122KB, addressing size flagged by an OG share tester
- Fixes a pre-existing markdownlint MD024 config gap (root config was missing the `siblings_only` override `nuxt/.markdownlint.jsonc` already had) causing CHANGELOG.md false positives
- Adds a `size-limit` check (200 KB brotli budget, ~157 KB baseline) for the client JS bundle to both GitLab CI and GitHub Actions

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (incl. knip, style, docs, spell)
- [x] `pnpm test` (419 tests)
- [x] GitLab CI pipeline fully green (lint, test, typecheck, build, visual regression, SEO audit, bundle-size audit)
- [x] Manually verified via a Netlify draft deploy: splash timing behaves correctly, homepage renders real data, page weight confirmed at ~122KB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced activity and module data transferred from external services.
  * Added a client bundle size check with a 200 KB Brotli limit.

* **User Experience**
  * Improved homepage splash-screen timing by waiting for essential content and fonts to load.
  * Enhanced splash fade-in and fade-out transitions.

* **Bug Fixes**
  * Improved handling of loading and error states for homepage activity content.

* **Testing**
  * Added coverage for trimmed activity data and updated visual test timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->